### PR TITLE
cargo: update to tiny-bip39 v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,6 @@ name = "paperback-core"
 version = "0.0.0"
 dependencies = [
  "aead",
- "anyhow",
  "chacha20poly1305",
  "criterion",
  "crypto-common",
@@ -1140,11 +1139,12 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -1767,12 +1767,10 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
+checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
- "anyhow",
- "hmac",
  "once_cell",
  "pbkdf2",
  "rand",

--- a/pkg/paperback-core/Cargo.toml
+++ b/pkg/paperback-core/Cargo.toml
@@ -30,7 +30,6 @@ edition = "2021"
 
 [dependencies]
 aead = { version = "^0.5", features = ["std"] }
-anyhow = "^1"
 chacha20poly1305 = "^0.10"
 crypto-common = "^0.1"
 digest = "^0.10"
@@ -48,7 +47,7 @@ qrcode = "^0.14"
 serde = { version = "^1", features = ["derive"] }
 signature = "^2"
 thiserror = "^1"
-tiny-bip39 = "^1.0"
+tiny-bip39 = "^2"
 typenum = "^1"
 unsigned-varint = { version = "^0.7", features = ["nom"] }
 

--- a/pkg/paperback-core/src/v0/mod.rs
+++ b/pkg/paperback-core/src/v0/mod.rs
@@ -88,15 +88,6 @@ pub enum Error {
     Other(String),
 }
 
-impl From<anyhow::Error> for Error {
-    fn from(inner: anyhow::Error) -> Self {
-        match inner.downcast::<bip39::ErrorKind>() {
-            Ok(err) => Self::Bip39(err),
-            Err(err) => Self::Other(err.to_string()),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Identity {
     id_public_key: VerifyingKey,
@@ -230,7 +221,7 @@ impl KeyShard {
 
         // Convert key to a BIP-39 mnemonic.
         let phrase = Mnemonic::from_entropy(&shard_key, CODEWORD_LANGUAGE)
-            .map_err(Error::from)? // XXX: Ugly, fix this.
+            .map_err(Error::Bip39)?
             .into_phrase();
         let codewords = phrase
             .split_whitespace()


### PR DESCRIPTION
They moved away from using anyhow in a library (which is not recommended), so we can finally remove the ugly anyhow dependency in paperback-core.

Closes #122
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>