### PR TITLE
Implemented Dockerfile (with related documentation)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use the Alpine-based Rust image as builder
+FROM rust:alpine AS builder
+RUN apk add --no-cache musl-dev gcc
+WORKDIR /usr/src/paperback
+COPY . .
+RUN RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
+
+FROM alpine:3 AS runner
+RUN apk add --no-cache libgcc
+COPY --from=builder /usr/src/paperback/target/release/paperback /usr/local/bin/
+RUN chmod +x /usr/local/bin/paperback
+
+WORKDIR /data
+ENTRYPOINT ["paperback"]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,32 @@ version of the documents.
 [rust]: https://www.rust-lang.org/
 [cargo]: https://doc.rust-lang.org/cargo/
 
+#### Run in a Docker container
+You can run `paperback` in a very lightweight Alpine based Docker container
+(less than 20 MB). This is useful if don't want or you can't install the rust
+build toolchain on your system. To run `paperback` in a Docker container, you
+must first clone this repo or download the ZIP file of the code, then run the
+following command:
+```bash
+docker build -t paperback .
+```
+Then you can `cd` the directory where the files you need to backup are located
+and run the following command:
+```bash
+docker run --rm -v ${PWD}:/data paperback backup -n THRESHOLD -k SHARDS INPUT_FILE
+```
+all the commands runs exactly how described in the section above. This solution
+will create a temporary docker container that will be deleted after the command
+is executed.
+
+If you need to run multiple commands and you prefer an interactive terminal, you
+can run the following command instead of the previous one:
+```bash
+docker run --rm -it -v ${PWD}:/data --entrypoint /bin/sh paperback
+```
+then you can run all the `paperback` commands you need. When you finish, type
+`exit` to close the terminal and destroy the container.
+
 ### Paper Choices and Storage ###
 
 One of the most important things when considering using `paperback` is to keep


### PR DESCRIPTION
Hi, first of all thank you for this great project!
I like running commands in Docker containers so I've make paperback runnable in a very lightweight Alpine based docker container. I've also added a subsection in the usage README. The usage is the same as describe for local, but the user doesn't have to install the Rust toolchain (maybe he doesn't want or he can't).
By now, the container must be built by the end user (it's a very easy step and it is describe in the documentation) but requires a couple of minutes. Would be great to use the Github Packages builtin Docker registry to make it available already built as described here: [Publishing Docker images](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images). What do you think about that?